### PR TITLE
HW06 is completed

### DIFF
--- a/hw06_pipeline_execution/go.mod
+++ b/hw06_pipeline_execution/go.mod
@@ -1,4 +1,4 @@
-module github.com/fixme_my_friend/hw06_pipeline_execution
+module github.com/j85529016-prog/GoProf_01/hw06_pipeline_execution
 
 go 1.23
 

--- a/hw06_pipeline_execution/pipeline.go
+++ b/hw06_pipeline_execution/pipeline.go
@@ -9,6 +9,58 @@ type (
 type Stage func(in In) (out Out)
 
 func ExecutePipeline(in In, done In, stages ...Stage) Out {
-	// Place your code here.
-	return nil
+	if in == nil {
+		// Если входной канал пустой - возвращаем закрытый входной канал
+		result := make(Bi)
+		close(result)
+		return result
+	}
+
+	// Начинаем с входного канала
+	out := in
+	// Запускаем стадии по цепочке
+	for _, stage := range stages {
+		// Каждая стадия возвращает свой канал, мы оборачиваем его функции, чтобы использовать done,
+		// так как в stage напрямую канал done не передается по сигнатуре
+		out = wrapStage(stage(out), done)
+	}
+	return out
+}
+
+func wrapStage(in, done In) Out {
+	processOut := make(Bi)
+
+	go func() {
+		defer func() {
+			// Закрываем выходной канал по завершению работы
+			close(processOut)
+			// Вычитываем пустым циклом входной канал, чтобы избежать deadlock горутин, запускаемых внутри стадий
+			for v := range in {
+				_ = v // заглушка для линтера (revive)
+			}
+		}()
+
+		for {
+			select {
+			case <-done:
+				// Если пришёл сигнал завершения — выходим
+				return
+			case v, ok := <-in:
+				if !ok {
+					// Если входной канал закрыт — выходим
+					return
+				}
+
+				select {
+				case <-done:
+					// Если во время v, ok := <-in пришёл сигнал done — выходим
+					return
+				case processOut <- v:
+					// Записываем в выходной канал - продолжаем работу
+				}
+			}
+		}
+	}()
+
+	return processOut
 }

--- a/hw06_pipeline_execution/pipeline_test.go
+++ b/hw06_pipeline_execution/pipeline_test.go
@@ -145,6 +145,28 @@ func TestAllStageStop(t *testing.T) {
 		wg.Wait()
 
 		require.Len(t, result, 0)
-
 	})
+}
+
+func TestNoStages(t *testing.T) {
+	in := make(Bi)
+	go func() {
+		in <- 1
+		in <- 2
+		close(in)
+	}()
+
+	// done не используем
+	result := make([]int, 0)
+	for v := range ExecutePipeline(in, nil) {
+		result = append(result, v.(int))
+	}
+
+	require.Equal(t, []int{1, 2}, result)
+}
+
+func TestNilInput(t *testing.T) {
+	out := ExecutePipeline(nil, nil)
+	_, ok := <-out
+	require.False(t, ok, "выходной канал должен быть закрыт при nil входе")
 }


### PR DESCRIPTION
## Домашнее задание №6 «Пайплайн»
**Задача:** реализовать функцию для запуска конкуррентного пайплайна, состоящего из стейджей.

![image](https://github.com/user-attachments/assets/e0ba8726-3ecf-4ce5-b6e7-f797281e3eba)


*Пайплайн* - последовательность действий или процессов, которые выполняются для достижения цели.
*Стейдж* - функция, принимающая канал на чтение и отдающая канал на чтение, внутри в горутине берущая данные из входного канала, выполняющая полезную работу и отдающая результат в выходной канал:
```golang
func Stage(in <-chan interface{}) (out <-chan interface{}) {
    out = make(chan interface{})
    go func() { /* Some work */ }()
    return out
}
```

**Требования:**
- Параллельное выполнение заданий стейджами.
- Возможность остановить пайплайн через дополнительный  сигнальный канал (`done`/`terminate`/etc.)

![image](https://github.com/user-attachments/assets/19461acf-384d-45b2-9040-024a24976b07)

Параллельное(конкурентное) выполнение задач подразумевает, что после обработки порции данных, стейдж передаёт результат в следующий за ним стейдж или на выход пайплайна и принимает в работу (или готов принять в работу) следующую порцию данных. Другими словами, пайплайн не ждёт, когда вся цепочка стейджей обработает один входящий элемент, чтобы принять в обработку следующий. Пока есть данные в канале все стейджи выполняют полезную работу параллельно.
Т.е. пайплан из 4 функций по 100 мс каждая для 5 входных элементов **должен выполняться
гораздо быстрее**, чем за 2 секунды (4 * 100 мс * 5).

При необходимости можно выделять дополнительные функции.

**Нельзя менять сигнатуры исходных функций.**

Для большего понимания см. тесты.

### Критерии оценки
- CI-пайплайн зелёный - 5 баллов
- Добавлены новые юнит-тесты - до 2 баллов
- Понятность и чистота кода - до 3 баллов

#### Зачёт от 7 баллов

### Подсказки
- https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
- `go test -v -race -count=100 .`
